### PR TITLE
Add mix nonce support for quick PoW verification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ethash"
 description = "An Apache-licensed Ethash implementation."
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Wei Tang <hi@that.world>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -43,7 +43,8 @@ impl<P: Patch> LightDAG<P> {
     }
 
     pub fn hashimoto(&self, hash: H256, nonce: H64) -> (H256, H256) {
-        crate::hashimoto_light(hash, nonce, self.full_size, &self.cache)
+        let (mix_hash, result, _) = crate::hashimoto_light(hash, nonce, self.full_size, &self.cache);
+        (mix_hash, result)
     }
 
     pub fn is_valid_for(&self, number: U256) -> bool {

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -42,7 +42,7 @@ impl<P: Patch> LightDAG<P> {
         }
     }
 
-    pub fn hashimoto(&self, hash: H256, nonce: H64) -> (H256, H256, [u8; crate::MIX_BYTES / 4]) {
+    pub fn hashimoto(&self, hash: H256, nonce: H64) -> ([u8; crate::MIX_BYTES / 4], H256) {
         crate::hashimoto_light(hash, nonce, self.full_size, &self.cache)
     }
 

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -42,9 +42,8 @@ impl<P: Patch> LightDAG<P> {
         }
     }
 
-    pub fn hashimoto(&self, hash: H256, nonce: H64) -> (H256, H256) {
-        let (mix_hash, result, _) = crate::hashimoto_light(hash, nonce, self.full_size, &self.cache);
-        (mix_hash, result)
+    pub fn hashimoto(&self, hash: H256, nonce: H64) -> (H256, H256, [u8; crate::MIX_BYTES / 4]) {
+        crate::hashimoto_light(hash, nonce, self.full_size, &self.cache)
     }
 
     pub fn is_valid_for(&self, number: U256) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,7 +321,10 @@ pub fn hashimoto_pre_validate(
     )
 }
 
-pub fn hashimoto_pre_validate_with_hasher<HF256: Fn(&[u8]) -> [u8; 32], HF512: Fn(&[u8]) -> [u8; 64]>(
+pub fn hashimoto_pre_validate_with_hasher<
+    HF256: Fn(&[u8]) -> [u8; 32],
+    HF512: Fn(&[u8]) -> [u8; 64],
+>(
     header_hash: H256,
     nonce: H64,
     mix_nonce: [u8; MIX_BYTES / 4],
@@ -494,7 +497,7 @@ pub fn get_seedhash(epoch: usize) -> H256 {
 
 #[cfg(test)]
 mod tests {
-    use crate::{EthereumPatch, LightDAG, hashimoto_pre_validate};
+    use crate::{hashimoto_pre_validate, EthereumPatch, LightDAG};
     use ethereum_types::{H256, H64};
     use hex_literal::*;
 
@@ -525,8 +528,8 @@ mod tests {
         let partial_header_hash = H256::from(hex!(
             "3c2e6623b1de8862a927eeeef2b6b25dea6e1d9dad88dca3c239be3959dc384a"
         ));
-        let (mixh, result, mix) = light_dag
-            .hashimoto(partial_header_hash, H64::from(hex!("a5d3d0ccc8bb8a29")));
+        let (mixh, result, mix) =
+            light_dag.hashimoto(partial_header_hash, H64::from(hex!("a5d3d0ccc8bb8a29")));
         assert_eq!(
             H256::from(mix),
             H256::from(hex!(
@@ -534,7 +537,11 @@ mod tests {
             ))
         );
         assert_eq!(H256::from(mix), mixh);
-        let (mixh_verif, result_verif) = hashimoto_pre_validate(partial_header_hash, H64::from(hex!("a5d3d0ccc8bb8a29")), mix);
+        let (mixh_verif, result_verif) = hashimoto_pre_validate(
+            partial_header_hash,
+            H64::from(hex!("a5d3d0ccc8bb8a29")),
+            mix,
+        );
         assert_eq!(mixh, mixh_verif);
         assert_eq!(result, result_verif);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,7 +298,7 @@ pub fn hashimoto_with_hasher<
 pub fn hashimoto_pre_validate(
     header_hash: H256,
     nonce: H64,
-    mix_nonce: [u8; MIX_BYTES / 4],
+    mix_nonce: &[u8; MIX_BYTES / 4],
 ) -> H256 {
     hashimoto_pre_validate_with_hasher(
         header_hash,
@@ -327,7 +327,7 @@ pub fn hashimoto_pre_validate_with_hasher<
 >(
     header_hash: H256,
     nonce: H64,
-    mix_nonce: [u8; MIX_BYTES / 4],
+    mix_nonce: &[u8; MIX_BYTES / 4],
     hasher256: HF256,
     hasher512: HF512,
 ) -> H256 {
@@ -341,7 +341,7 @@ pub fn hashimoto_pre_validate_with_hasher<
     let result = {
         let mut data = [0u8; 64 + MIX_BYTES / 4];
         data[..64].copy_from_slice(&s);
-        data[64..].copy_from_slice(&mix_nonce);
+        data[64..].copy_from_slice(mix_nonce);
         hasher256(&data)
     };
     H256::from(result)
@@ -541,7 +541,7 @@ mod tests {
         let result_verif = hashimoto_pre_validate(
             partial_header_hash,
             H64::from(hex!("a5d3d0ccc8bb8a29")),
-            mix,
+            &mix,
         );
         assert_eq!(result, result_verif);
     }


### PR DESCRIPTION
More details on how this should work are [here](https://ethereum.org/en/developers/docs/consensus-mechanisms/pow/mining-algorithms/ethash#main-loop).